### PR TITLE
Minor fix for ExternalReference entity declarations

### DIFF
--- a/src/main/java/fi/vm/yti/codelist/common/model/ExternalReference.java
+++ b/src/main/java/fi/vm/yti/codelist/common/model/ExternalReference.java
@@ -168,7 +168,7 @@ public class ExternalReference extends AbstractBaseCode implements Serializable 
     }
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "parentcodescheme_id", nullable = false, insertable = true, updatable = false)
+    @JoinColumn(name = "parentcodescheme_id", nullable = true, insertable = true, updatable = false)
     @JsonView(Views.ExtendedExternalReference.class)
     public CodeScheme getParentCodeScheme() {
         return parentCodeScheme;


### PR DESCRIPTION
Relational model allows `null` value for `ExternalReference.parentCodeScheme` but domain model expected it's value to be always non null => Hibernate generated too restrictive inner joins.

Relates to https://jira.csc.fi/browse/YTI-480
